### PR TITLE
Updating documentation to include local LLM use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ pip install kait
 ]
 ```
 
+### Using a Local LLM
+
+You can use OpenAI compatible local LLMs by including a `base_url` in your model spec:
+
+```
+[
+    {
+        "model": "chatglm2-6b",
+        "base_url": "http://localhost:8000/v1",
+        "api_key": "NULL", # Any string will do
+    }
+]
+```
+
+[FastChat/](https://github.com/lm-sys/FastChat) and [llama-cpp-python](https://llama-cpp-python.readthedocs.io/en/latest/) both provide OpenAI compatible APIs which can be used with the above config. Which models provide adequate performance still needs validating.
+
 ## Usage
 
 `kait` requires kubectl to be installed and authenticated against the cluster you want to use.

--- a/tests/test_kubectl_executor_agent.py
+++ b/tests/test_kubectl_executor_agent.py
@@ -5,7 +5,13 @@ from kait.kubectl_executor_agent import KubectlExecutorAgent
 
 def test_execute_code_blocks_when_read_only_then_allow_read_execution():
     """Allow read commands when read_only=False."""
-    executor_agent = KubectlExecutorAgent(name="test_kait", read_only=True)
+    executor_agent = KubectlExecutorAgent(
+        name="test_kait",
+        read_only=True,
+        code_execution_config={
+            "use_docker": False,
+        },
+    )
 
     executor_agent.run_code = MagicMock(return_value=(0, "", ""))
 
@@ -17,7 +23,13 @@ def test_execute_code_blocks_when_read_only_then_allow_read_execution():
 
 def test_execute_code_blocks_when_read_only_then_prevent_create_execution():
     """Prevent CUD commands when read_only=True."""
-    executor_agent = KubectlExecutorAgent(name="test_kait", read_only=True)
+    executor_agent = KubectlExecutorAgent(
+        name="test_kait",
+        read_only=True,
+        code_execution_config={
+            "use_docker": False,
+        },
+    )
 
     code_blocks = [("bash", "kubectl create deployment nginx --image nginx")]
 
@@ -27,7 +39,13 @@ def test_execute_code_blocks_when_read_only_then_prevent_create_execution():
 
 def test_execute_code_blocks_when_not_read_only_then_allow_create_execution():
     """Allow CRUD commands when read_only=False."""
-    executor_agent = KubectlExecutorAgent(name="test_kait", read_only=False)
+    executor_agent = KubectlExecutorAgent(
+        name="test_kait",
+        read_only=False,
+        code_execution_config={
+            "use_docker": False,
+        },
+    )
 
     executor_agent.run_code = MagicMock(return_value=(0, "", ""))
 
@@ -39,7 +57,13 @@ def test_execute_code_blocks_when_not_read_only_then_allow_create_execution():
 
 def test_execute_code_blocks_when_blocking_command_used_then_prevent_execution():
     """Prevent commands that block execution."""
-    executor_agent = KubectlExecutorAgent(name="test_kait", read_only=False)
+    executor_agent = KubectlExecutorAgent(
+        name="test_kait",
+        read_only=False,
+        code_execution_config={
+            "use_docker": False,
+        },
+    )
 
     executor_agent.run_code = MagicMock(return_value=(0, "", ""))
 


### PR DESCRIPTION
Documenting `base_url` for local LLM usage.

Fixing test error by passing `code_execution_config={"use_docker": False}` to the agent.